### PR TITLE
github-emoji-form-submit 1.0.1 Added badges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
+Copyright (c) 2015-16 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# github-emoji-form-submit [![Support this project][donate-now]][paypal-donations]
+# github-emoji-form-submit [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/github-emoji-form-submit.svg)](https://www.npmjs.com/package/github-emoji-form-submit) [![Downloads](https://img.shields.io/npm/dt/github-emoji-form-submit.svg)](https://www.npmjs.com/package/github-emoji-form-submit) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
-Autocomplete selected Emoji when submitting forms on GitHub.com.
+> Autocomplete selected Emoji when submitting forms on GitHub.com.
 
 When leaving comments, opening issues etc. you can use
 `:emoji:`. That's pretty neat. But often, it happened


### PR DESCRIPTION
- Added badges :tada:
  - [PayPal Donations](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW)
  - npm downloads
  - npm version
  - Travis (if there are tests)
  - [CodeMentor](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)–you can ping me there if you need help with one of these modules (or help in general).
- Updated the LICENSE year. :fireworks:
