### PR TITLE
github-emoji-form-submit 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# github-emoji-form-submit [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/github-emoji-form-submit.svg)](https://www.npmjs.com/package/github-emoji-form-submit) [![Downloads](https://img.shields.io/npm/dt/github-emoji-form-submit.svg)](https://www.npmjs.com/package/github-emoji-form-submit) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# github-emoji-form-submit
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/github-emoji-form-submit.svg)](https://www.npmjs.com/package/github-emoji-form-submit) [![Downloads](https://img.shields.io/npm/dt/github-emoji-form-submit.svg)](https://www.npmjs.com/package/github-emoji-form-submit) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Autocomplete selected Emoji when submitting forms on GitHub.com.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-emoji-form-submit",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Autocomplete selected Emoji when submitting forms on GitHub.com.",
   "main": "lib/index.js",
   "scripts": {
@@ -81,6 +81,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
